### PR TITLE
Updated jsdom and sockjs-client-node to support NodeJS version 0.12.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var scope = require('jsdom').jsdom().createWindow()
+var scope = require('jsdom').jsdom().defaultView
   , library = __dirname + '/lib/vertxbus.js/index.js'
   , read = require('fs').readFileSync;
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/muraken720/vertx-eventbus-client/issues"
   },
   "dependencies": {
-    "jsdom": "0.10.x",
-    "sockjs-client-node": "0.1.1"
+    "jsdom": "3.1.2",
+    "sockjs-client-node": "^0.2.1"
   },
   "keywords": [
     "vert.x",


### PR DESCRIPTION
With latest version of NodeJS, jsdom was giving errors. Updated versions of jsdom and sockjs-client that are compatible with latest NodeJS version. Also update index.js code to support new version of jsdom.

```
~/vertx-eventbus-client/node_modules/jsdom/lib/jsdom/level1/core.js:553
      Array.prototype.splice.call(this._childNodes, refChildIndex, 0, newChild
                             ^
TypeError: Cannot set property length of [object Object] which has only a getter
    at core.Node.insertBefore (~/vertx-eventbus-client/node_modules/jsdom/lib/jsdom/level1/core.js:553:30)
    at null.<anonymous> (~/vertx-eventbus-client/node_modules/jsdom/lib/jsdom/level2/events.js:332:20)
    at proto.(anonymous function) [as insertBefore] (~/vertx-eventbus-client/node_modules/jsdom/lib/jsdom/utils.js:23:26)
    at WebSocket.onError (~/vertx-eventbus-client/node_modules/sockjs-client-node/node_modules/ws/lib/WebSocket.js:370:18)
    at WebSocket.emit (events.js:107:17)
    at ClientRequest.<anonymous> (~/vertx-eventbus-client/node_modules/sockjs-client-node/node_modules/ws/lib/WebSocket.js:579:10)
    at ClientRequest.emit (events.js:107:17)
    at Socket.socketErrorListener (_http_client.js:271:9)
    at Socket.emit (events.js:107:17)
    at net.js:459:14
    at process._tickCallback (node.js:355:11)
```

JSDom issue talking same: https://github.com/assetgraph/assetgraph-builder/issues/162
